### PR TITLE
Fix `npm` package publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nunjucks-loader
+# Nunjucks templates loader for Webpack
 This Webpack loader compiles [Nunjucks](https://github.com/mozilla/nunjucks) templates.
 [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin) compatible. 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest",
     "posttest": "rm -rf ./test/bundles/",
     "preversion": "npm test",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "babel src --out-dir=lib",
     "pretest": "eslint src",
     "test": "jest",
-    "posttest": "rm -rf ./test/bundles/"
+    "posttest": "rm -rf ./test/bundles/",
+    "preversion": "npm test",
+    "postversion": "git push && git push --tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Published package actually didn't match the source and contains one of the early versions of loader.