### PR TITLE
Simplify matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: node_js
 
+os:
+  - linux
+  - windows
+
+node_js:
+  - "8.9.0"
+  - "lts/*"
+
+env:
+  - EXCLUDE_ASSETS=1
+
 jobs:
-  include:
+  exclude:
     - os: linux
-      node_js: "8.9.0"
-    - os: linux
-      node_js: "lts/*"
-    - os: windows
-      node_js: "8.9.0"
-      env: EXCLUDE_ASSETS=1
-    - os: windows
-      node_js: "lts/*"
       env: EXCLUDE_ASSETS=1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ jobs:
   include:
     - os: linux
       node_js: "8.9.0"
-      env: COVERAGE=1
     - os: linux
       node_js: "lts/*"
-      env: COVERAGE=1
     - os: windows
       node_js: "8.9.0"
       env: EXCLUDE_ASSETS=1
@@ -16,7 +14,7 @@ jobs:
       env: EXCLUDE_ASSETS=1
 
 script:
-  - npm test -- ${COVERAGE:+--coverage} ${EXCLUDE_ASSETS:+--testPathIgnorePatterns assets.test.js}
+  - npm test -- --coverage ${EXCLUDE_ASSETS:+--testPathIgnorePatterns assets.test.js}
 
 after_success:
-  - if [ "$COVERAGE" ]; then cat test/.coverage/lcov.info | coveralls ; fi
+  - cat test/.coverage/lcov.info | coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ node_js:
   - "lts/*"
 
 env:
+  # We need to preserve builds for linux without env
+  - PRESERVE_BUILD=LINUX
   - EXCLUDE_ASSETS=1
 
 jobs:
   exclude:
     - os: linux
       env: EXCLUDE_ASSETS=1
+    - os: windows
+      env: PRESERVE_BUILD=LINUX
 
 script:
   - npm test -- --coverage ${EXCLUDE_ASSETS:+--testPathIgnorePatterns assets.test.js}


### PR DESCRIPTION
- Return coverage for Windows builds
- Change `jobs.include` to `jobs.exclude`, to exclude Windows builds with assets