### PR TITLE
Extend asynchronous support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ so bundle get rebuild in watch mode only when required.
 
 ### Asynchronous support
 
-When loader found async filter in template dependencies, it returns `Promise`,
+When loader found async tags or async filters or extensions in the template,
+it calls `render` with callback under the hood, and returns `Promise`,
 instead of render result.
 
 ## Options

--- a/src/ast/has-async-tags.js
+++ b/src/ast/has-async-tags.js
@@ -1,0 +1,17 @@
+import nunjucks from 'nunjucks';
+
+/**
+ * @param {nunjucks.nodes.Root} nodes
+ * @returns {boolean}
+ */
+export function hasAsyncTags(nodes) {
+    return [
+        nunjucks.nodes.IfAsync,
+        nunjucks.nodes.AsyncEach,
+        nunjucks.nodes.AsyncAll,
+        nunjucks.nodes.FilterAsync,
+        nunjucks.nodes.CallExtensionAsync
+    ].some(function examineNodes(nodeType) {
+        return nodes.findAll(nodeType).length > 0;
+    });
+}

--- a/src/loader.js
+++ b/src/loader.js
@@ -80,15 +80,7 @@ export default function nunjucksLoader(source) {
               );
 
               if (nunjucks.isAsync()) {
-                return new Promise(function(resolve, reject) {
-                  nunjucks.render(${resourcePathString}, ctx, function(err, res) {
-                    if (err) {
-                      return reject(err);
-                    }
-                    
-                    resolve(res);
-                  });
-                });
+                return nunjucks.renderAsync(${resourcePathString}, ctx);
               }
             
               return nunjucks.render(${resourcePathString}, ctx);

--- a/src/loader.js
+++ b/src/loader.js
@@ -36,7 +36,8 @@ export default function nunjucksLoader(source) {
         precompiled,
         globals,
         extensions,
-        filters
+        filters,
+        isAsyncTemplate
     }) => {
         const hasAssets = Object.keys(assets).length > 0;
         const assetsUUID = toAssetsUUID(assets);
@@ -53,16 +54,16 @@ export default function nunjucksLoader(source) {
         } = getFilters(filters);
 
         const resourcePathString = JSON.stringify(resourcePathImport);
-        // Only required options
-        // https://mozilla.github.io/nunjucks/api.html#constructor
         const envOptions = JSON.stringify({
+            // https://mozilla.github.io/nunjucks/api.html#constructor
             autoescape: options.autoescape,
             throwOnUndefined: options.throwOnUndefined,
             trimBlocks: options.trimBlocks,
             lstripBlocks: options.lstripBlocks,
             // Loader specific options
             jinjaCompat: options.jinjaCompat,
-            isWindows
+            isWindows,
+            isAsyncTemplate
         });
         callback(null, `
             ${getRuntimeImport(this)}

--- a/src/precompile/get-dependencies.js
+++ b/src/precompile/get-dependencies.js
@@ -7,6 +7,7 @@ import {getUsedExtensions} from '../ast/get-used-extensions';
 import {getUsedFilters} from '../ast/get-used-filters';
 import {getAssets} from '../ast/get-assets';
 import {getTemplatesImports} from '../ast/get-templates-imports';
+import {hasAsyncTags} from '../ast/has-async-tags';
 
 /**
  * @typedef {Object} NunjucksOptions
@@ -83,7 +84,8 @@ export async function getDependencies(resourcePath, source, options) {
         return getAssets(nodes, assetsPaths).then(function(assets) {
             return {
                 ...deps,
-                assets
+                assets,
+                isAsyncTemplate: hasAsyncTags(nodes)
             };
         })
     });

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -53,7 +53,7 @@ module.exports = function runtime(options, {
         },
 
         renderAsync(name, ctx) {
-            return new Promise(function(resolve, reject) {
+            return new Promise(function renderCallback(resolve, reject) {
                 env.render(name, ctx, function(error, response) {
                     if (error) {
                         return reject(error);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -48,8 +48,20 @@ module.exports = function runtime(options, {
     }
 
     return {
-        render(name, ctx, cb) {
-            return env.render(name, ctx, cb);
+        render(name, ctx) {
+            return env.render(name, ctx);
+        },
+
+        renderAsync(name, ctx) {
+            return new Promise(function(resolve, reject) {
+                env.render(name, ctx, function(error, response) {
+                    if (error) {
+                        return reject(error);
+                    }
+
+                    resolve(response);
+                });
+            });
         },
 
         isAsync() {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -65,7 +65,10 @@ module.exports = function runtime(options, {
         },
 
         isAsync() {
-            return Object.values(filters).some(({async}) => async === true);
+            return (
+                options.isAsyncTemplate === true ||
+                Object.values(filters).some(({async}) => async === true)
+            );
         }
     };
 };

--- a/src/utils/to-list-item.js
+++ b/src/utils/to-list-item.js
@@ -10,9 +10,9 @@ export function toListItem(list, callback) {
      * @param {Object<TNode>} item
      * @returns {?TNode}
      */
-    function foo(item) {
+    function findItem(item) {
         return list.find(callback(item));
     }
 
-    return foo;
+    return findItem;
 }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Advanced compilation extensions should compile async extensions 1`] = `
+"<div id=\\"el100500\\">(async): 
+  This content will be replaced with the content from /stuff
+</div>
+
+
+    <div>
+        <div id=\\"el100500\\">(async): 
+          Content 1
+        </div>
+    </div>
+
+    <div>
+        <div id=\\"el100500\\">(async): 
+          Content 2
+        </div>
+    </div>
+
+"
+`;
+
 exports[`Advanced compilation extensions should compile custom tags 1`] = `
 "<div id=\\"el100500\\">
   This content will be replaced with the content from /stuff

--- a/test/fixtures/extensions/RemoteAsyncExtension.js
+++ b/test/fixtures/extensions/RemoteAsyncExtension.js
@@ -1,0 +1,40 @@
+const nunjucks = require('nunjucks/browser/nunjucks-slim');
+
+function RemoteExtension() {
+    this.tags = ['remote'];
+
+    this.parse = function(parser, nodes, lexer) {
+        // get the tag token
+        var tok = parser.nextToken();
+
+        // parse the args and move after the block end. passing true
+        // as the second arg is required if there are no parentheses
+        var args = parser.parseSignature(null, true);
+        parser.advanceAfterBlockEnd(tok.value);
+
+        // parse the body and possibly the error block, which is optional
+        var body = parser.parseUntilBlocks('error', 'endremote');
+        var errorBody = null;
+
+        if(parser.skipSymbol('error')) {
+            parser.skip(lexer.TOKEN_BLOCK_END);
+            errorBody = parser.parseUntilBlocks('endremote');
+        }
+
+        parser.advanceAfterBlockEnd();
+
+        // See above for notes about CallExtension
+        return new nodes.CallExtensionAsync(this, 'run', args, [body, errorBody]);
+    };
+
+    this.run = function(context, url, body, errorBody, callback) {
+        var id = 'el' + 100500;
+        var ret = new nunjucks.runtime.SafeString('<div id="' + id + '">(async): ' + body() + '</div>');
+
+        setTimeout(function() {
+            callback(null, ret);
+        }, 1000);
+    };
+}
+
+module.exports = new RemoteExtension();

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -130,6 +130,24 @@ describe('Advanced compilation', function() {
 
             expect(output()).toMatchSnapshot();
         });
+
+        test('should compile async extensions', async function() {
+            const output = await compiler('fixtures/extensions/multiple.njk', {
+                extensions: {
+                    RemoteExtension: path.join(__dirname, './fixtures/extensions/RemoteAsyncExtension.js')
+                }
+            });
+
+            jest.useFakeTimers();
+
+            const asyncRender = output();
+
+            jest.runAllTimers();
+
+            await expect(asyncRender).resolves.toMatchSnapshot();
+
+            jest.useRealTimers();
+        });
     });
 
     describe('filters', function() {


### PR DESCRIPTION
`Promise` would be returned, if template has async tags like `asyncEach` and `asyncAll`, and async extensions.