### PR TITLE
Replace `prepublishOnly` with `prepack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "posttest": "rm -rf ./test/bundles/",
     "preversion": "npm test",
     "postversion": "git push && git push --tags",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It has more meaning than `prepublishOnly`. Also i hope this will help with testing module without publishing it to npm.