### PR TITLE
Fix trailing slash with `path.resolve`

### DIFF
--- a/src/output/get-assets.js
+++ b/src/output/get-assets.js
@@ -21,10 +21,16 @@ export function getAssets(assets) {
                 importPath = assetImport.split(' + ').map(
                     function(part) {
                         if (part.startsWith('"')) {
-                            return stringifyRequest(
+                            let nextPart = stringifyRequest(
                                 loaderContext,
                                 part.replace(/^"|"$/g, '')
                             );
+
+                            if (!nextPart.endsWith('/"') && part.endsWith('/"')) {
+                                nextPart = nextPart.replace(/"$/, '/"');
+                            }
+
+                            return nextPart;
                         }
 
                         return part;

--- a/src/utils/resolve-search-paths.js
+++ b/src/utils/resolve-search-paths.js
@@ -3,7 +3,11 @@ import {unquote} from './unquote';
 
 function getFilePath(searchPath, possiblePath) {
     const [firstPart, ...restParts] = possiblePath.split(' + ');
-    const filePath = path.resolve(searchPath, unquote(firstPart));
+    let filePath = path.resolve(searchPath, unquote(firstPart));
+
+    if (firstPart.endsWith('/"') && !filePath.endsWith('/')) {
+        filePath = `${filePath}/`;
+    }
 
     return restParts.length > 0 ?
         `${[`"${filePath}"`, ...restParts].join(' + ')}` : filePath;

--- a/test/__snapshots__/assets.test.js.snap
+++ b/test/__snapshots__/assets.test.js.snap
@@ -29,6 +29,15 @@ exports[`Assets should load dynamic assets 1`] = `
 "
 `;
 
+exports[`Assets should load dynamic assets with trailing slashes 1`] = `
+"
+<p>bundles/fixtures/django_project/app_example/static/foo/bar/dynamic-example-1.md</p>
+
+<p>bundles/fixtures/django_project/app_example/static/foo/bar/dynamic-example-2.md</p>
+
+"
+`;
+
 exports[`Assets should load exported dynamic assets 1`] = `
 "<!DOCTYPE html>
 <html lang=\\"en\\">

--- a/test/assets.test.js
+++ b/test/assets.test.js
@@ -1,3 +1,5 @@
+/* globals __USE_ES__ */
+
 import compiler from './compiler';
 
 const loaderOptions = {
@@ -22,6 +24,12 @@ describe('Assets', function() {
 
     test('should load dynamic assets', async function() {
         const output = await compiler('fixtures/assets/dynamic.njk', loaderOptions);
+
+        await expect(output()).resolves.toMatchSnapshot();
+    });
+
+    test('should load dynamic assets with trailing slashes', async function() {
+        const output = await compiler('fixtures/assets/dynamic-trailing-slash.njk', loaderOptions);
 
         await expect(output()).resolves.toMatchSnapshot();
     });

--- a/test/fixtures/assets/dynamic-trailing-slash.njk
+++ b/test/fixtures/assets/dynamic-trailing-slash.njk
@@ -1,0 +1,3 @@
+{% for fileName in ['dynamic-example-1.md', 'dynamic-example-2.md'] %}
+<p>{% static 'foo/bar/' + fileName %}</p>
+{% endfor %}


### PR DESCRIPTION
`path.resolve` is strip trailing slash, that is lead to bug, when dynamic assets from folder failed to resolve, because of that.

Fixes #87