### PR TITLE
Update bots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - support

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,6 +2,8 @@ daysUntilStale: 14
 daysUntilClose: 7
 exemptLabels:
   - pinned
+  - dependencies
+  - support
 staleLabel: stale
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
Prevent `stale` bot from closing `dependabot` PRs.